### PR TITLE
Fix bug in `yaml_safe_load`

### DIFF
--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -8,7 +8,7 @@ import ssl
 
 import paho.mqtt.client as mqtt
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 CONFIGURATION_KEY_NAMES = {
     "act_t": "action_topic",

--- a/ha_mqtt_discoverable/utils.py
+++ b/ha_mqtt_discoverable/utils.py
@@ -4,8 +4,8 @@
 # License: Apache 2.0
 
 import re
-import yaml
 
+import yaml
 from ha_mqtt_discoverable import CONFIGURATION_KEY_NAMES
 
 
@@ -28,7 +28,7 @@ def read_yaml_file(path: str = None) -> dict:
         Data decoded from YAML file content
     """
     with open(path) as yamlFile:
-        data = yaml.safe_load(yamlFile, Loader=yaml.FullLoader)
+        data = yaml.safe_load(yamlFile)
         return data
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ha-mqtt-discoverable"
-version = "0.4.0"
+version = "0.4.1"
 description = ""
 authors = ["Joe Block <jpb@unixorn.net>"]
 readme = "README.md"


### PR DESCRIPTION
# Description

When I switched to using `yaml_safe_load` I missed committing when I removed the Loader argument.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [x] Bug fix
- [ ] New feature
- [ ] Test updates
- [ ] Text cleanups/updates


# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
