### PR TITLE
Improve Dockerfile based on linting suggestions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ RUN apt-get update && \
     pip3 install --no-cache-dir ha-mqtt-discoverable && \
     pip3 cache purge
 
+USER nobody
+
 CMD ["bash", "-l"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ LABEL description="ha-mqtt-discoverable utility image"
 LABEL version=${application_version}
 
 RUN apt-get update && \
-    apt-get install -y apt-utils ca-certificates --no-install-recommends && \
+    apt-get install -y apt-utils=2.2.4 ca-certificates=20210119 --no-install-recommends && \
 		update-ca-certificates && \
 		rm -fr /tmp/* /var/lib/apt/lists/* && \
     /usr/bin/python3 -m pip install --upgrade pip --no-cache-dir && \
-    pip3 install --no-cache-dir ha-mqtt-discoverable && \
+    pip3 install --no-cache-dir ha-mqtt-discoverable==${application_version} && \
     pip3 cache purge
 
 USER nobody


### PR DESCRIPTION
# Description

From the `trivy` linter:
> HIGH: Specify at least 1 USER command in Dockerfile with non-root user as argument
  ════════════════════════════════════════
  Running containers with 'root' user can lead to a container escape situation. It is a best practice to run containers as non-root users, which can be done by adding a 'USER' statement to the Dockerfile.

From the `hadolint` linter:
>  /github/workspace/Dockerfile:1 DL3007 warning: Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag
  /github/workspace/Dockerfile:7 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
  /github/workspace/Dockerfile:7 DL3013 warning: Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [x] Bug fix
- [ ] New feature
- [ ] Test updates
- [ ] Text cleanups/updates


# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts added/updated in this PR are all marked executable.
- [x] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that any links added or updated in my PR are valid.
