### PR TITLE
Add tests to check if state is written to MQTT broker

### DIFF
--- a/tests/test_discoverable.py
+++ b/tests/test_discoverable.py
@@ -125,17 +125,18 @@ def test_str(discoverable: Discoverable[EntityInfo]):
     assert "settings" in string
 
 
+# Define a callback function to be invoked when we receive a message on the topic
+def message_callback(client: Client, userdata, message: MQTTMessage, tmp=None):
+    logging.info("Received %s", message)
+    payload = message.payload.decode()
+    assert "test" in payload
+    userdata.set()
+    client.disconnect()
+
+
 def test_publish_multithread(discoverable: Discoverable):
     received_message = Event()
-    mqtt_client = Client(protocol=MQTTv5)
-
-    # Define a callback function to be invoked when we receive a message on the topic
-    def message_callback(client: Client, userdata, message: MQTTMessage, tmp=None):
-        logging.info("Received {}", message)
-        payload = message.payload.decode()
-        assert "test" in payload
-        received_message.set()
-        mqtt_client.disconnect()
+    mqtt_client = Client(protocol=MQTTv5, userdata=received_message)
 
     mqtt_client.connect(host="localhost")
     mqtt_client.on_message = message_callback
@@ -162,15 +163,7 @@ def test_publish_multithread(discoverable: Discoverable):
 
 def test_publish_async(discoverable: Discoverable):
     received_message = Event()
-    mqtt_client = Client(protocol=MQTTv5)
-
-    # Define a callback function to be invoked when we receive a message on the topic
-    def message_callback(client: Client, userdata, message: MQTTMessage, tmp=None):
-        logging.info("Received {}", message)
-        payload = message.payload.decode()
-        assert "test" in payload
-        received_message.set()
-        mqtt_client.disconnect()
+    mqtt_client = Client(protocol=MQTTv5, userdata=received_message)
 
     mqtt_client.connect(host="localhost", clean_start=True)
     mqtt_client.on_message = message_callback

--- a/tests/test_discoverable.py
+++ b/tests/test_discoverable.py
@@ -1,3 +1,8 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import logging
+from threading import Event
+from paho.mqtt.client import Client, MQTTMessage, MQTTv5, SubscribeOptions
 import pytest
 from ha_mqtt_discoverable import DeviceInfo, Discoverable, Settings, EntityInfo
 
@@ -118,3 +123,70 @@ def test_str(discoverable: Discoverable[EntityInfo]):
     string = str(discoverable)
     print(string)
     assert "settings" in string
+
+
+def test_publish_multithread(discoverable: Discoverable):
+    received_message = Event()
+    mqtt_client = Client(protocol=MQTTv5)
+
+    # Define a callback function to be invoked when we receive a message on the topic
+    def message_callback(client: Client, userdata, message: MQTTMessage, tmp=None):
+        logging.info("Received {}", message)
+        payload = message.payload.decode()
+        assert "test" in payload
+        received_message.set()
+        mqtt_client.disconnect()
+
+    mqtt_client.connect(host="localhost")
+    mqtt_client.on_message = message_callback
+    mqtt_client.subscribe(
+        (
+            "homeassistant/binary_sensor/test/state/#",
+            SubscribeOptions(retainHandling=SubscribeOptions.RETAIN_DO_NOT_SEND),
+        )
+    )
+    mqtt_client.loop_start()
+
+    # Write a state to MQTT from another thread
+    with ThreadPoolExecutor() as executor:
+        future = executor.submit(discoverable._state_helper, "test")
+        # Wait for executor to finish
+        future.result(1)
+        # Check that flag is set
+        assert discoverable.wrote_configuration is True
+        assert discoverable.config_message is not None
+
+    # Wait until we receive the published message
+    assert received_message.wait(1)
+
+
+def test_publish_async(discoverable: Discoverable):
+    received_message = Event()
+    mqtt_client = Client(protocol=MQTTv5)
+
+    # Define a callback function to be invoked when we receive a message on the topic
+    def message_callback(client: Client, userdata, message: MQTTMessage, tmp=None):
+        logging.info("Received {}", message)
+        payload = message.payload.decode()
+        assert "test" in payload
+        received_message.set()
+        mqtt_client.disconnect()
+
+    mqtt_client.connect(host="localhost", clean_start=True)
+    mqtt_client.on_message = message_callback
+    mqtt_client.subscribe(
+        (
+            "homeassistant/binary_sensor/test/state/#",
+            SubscribeOptions(retainHandling=SubscribeOptions.RETAIN_DO_NOT_SEND),
+        )
+    )
+    mqtt_client.loop_start()
+
+    # Write a state to MQTT from an asyncio event loop
+    async def publish_state():
+        discoverable._state_helper("test")
+
+    asyncio.run(publish_state())
+
+    # Wait until we receive the published message
+    assert received_message.wait(1)


### PR DESCRIPTION
# Description
Add two integration tests that wait for the actual message to be published in the MQTT broker, to check that the message is actually published.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [ ] New feature
- [x] Test updates
- [ ] Text cleanups/updates


# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts added/updated in this PR are all marked executable.
- [x] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that any links added or updated in my PR are valid.
