### PR TITLE
Automate deployment on Git tag

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -16,25 +16,31 @@ jobs:
     name: Build and publish Python package
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Install poetry
-      run: pipx install poetry
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-        cache: 'poetry'
-    - name: Build wheel
-      run: poetry build
-    - name: Upload package
-      uses: actions/upload-artifact@v3
-      with:
-        name: Python package
-        path: dist/
-        if-no-files-found: error
-    - name: Publish wheel
-      run: poetry publish
-      continue-on-error: true  # TODO: only for testing
+      - uses: actions/checkout@v3
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "poetry"
+      - name: Bump version and build package
+        run: |
+          # Extract the package version from the latest git tag, removing the leading `v`
+          VERSION=$(git describe --tags --abbrev=0 | sed --quiet --regexp-extended 's/v(.*)/\1/p')
+          echo "$VERSION"
+          # Set package version using poetry CLI
+          poetry version "$VERSION"
+          poetry build
+      - name: Upload package
+        uses: actions/upload-artifact@v3
+        with:
+          name: Python package
+          path: dist/
+          if-no-files-found: error
+      - name: Publish wheel
+        run: |
+          poetry publish --username ${{ secrets.PYPI_USERNAME }} --password ${{ secrets.PYPI_PASSWORD }}
 
   docker-image:
     needs: build-wheel
@@ -60,4 +66,3 @@ jobs:
           push: true
           platforms: linux/arm64,linux/amd64,linux/arm/v7
           tags: ${{ github.repository }}:${{ github.ref_name }},${{ github.repository }}:latest
-

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,0 +1,63 @@
+# This workflow will build a Python wheel, a Docker image containing the CLI tool and publish both to PyPi and DockerHub
+
+name: Build and publish
+
+# Run only when pushing a Git version tag
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build-wheel:
+    name: Build and publish Python package
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install poetry
+      run: pipx install poetry
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+        cache: 'poetry'
+    - name: Build wheel
+      run: poetry build
+    - name: Upload package
+      uses: actions/upload-artifact@v3
+      with:
+        name: Python package
+        path: dist/
+        if-no-files-found: error
+    - name: Publish wheel
+      run: poetry publish
+      continue-on-error: true  # TODO: only for testing
+
+  docker-image:
+    needs: build-wheel
+    name: Build and publish Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Download Python package
+        uses: actions/download-artifact@v3
+        with:
+          name: Python package
+          path: dist/
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          build-args: |
+            application_version: ${{ github.ref_name }}
+          push: true
+          platforms: linux/arm64,linux/amd64,linux/arm/v7
+          tags: ${{ github.repository }}:${{ github.ref_name }},${{ github.repository }}:latest
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10
 
-ARG application_version="0.3.0"
+ARG application_version
 LABEL maintainer="Joe Block <jpb@unixorn.net>"
 LABEL description="ha-mqtt-discoverable utility image"
 LABEL version=${application_version}
@@ -8,9 +8,15 @@ LABEL version=${application_version}
 RUN apt-get update && \
     apt-get install -y apt-utils=2.2.4 ca-certificates=20210119 --no-install-recommends && \
 		update-ca-certificates && \
-		rm -fr /tmp/* /var/lib/apt/lists/* && \
-    pip install --no-cache-dir ha-mqtt-discoverable==${application_version} && \
-    pip cache purge
+		rm -fr /tmp/* /var/lib/apt/lists/*
+
+# Copy wheel file built by Poetry
+COPY dist/*.whl /app/
+
+RUN /usr/bin/python3 -m pip install --upgrade pip --no-cache-dir && \
+    pip3 install --no-cache-dir /app/*.whl && \
+    pip3 cache purge && \
+    rm -rf /app/*.whl
 
 USER nobody
 


### PR DESCRIPTION
# Description
- Add Github workflow triggered on Git tag `v*` to publish new versions
- Automatically build pip package using `poetry build`
- Automatically set package version during build using `poetry version` (inspired by [this post](https://nadeauinnovations.com/post/2020/08/one-version-to-rule-them-all-keeping-your-python-package-version-number-in-sync-with-git-and-poetry/)) First it needs #35 to have a single source of package version
- Copy built package inside the Docker image and install it, instead of installing from remote pip repository
- Automatically publish on PyPI 
- Automatically publish on Docker hub

TODO:
- define Github secrets `PYPI_USERNAME` and `PYPI_PASSWORD` to access PyPI
- define Docker Hub authentication to publish to it

Should we also use the Github container registry? This way the docker images are immediately visible under the [packages](https://github.com/unixorn?tab=packages&repo_name=ha-mqtt-discovery) section from this repo.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [x] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [x] New feature
- [ ] Test updates
- [ ] Text cleanups/updates


# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
