### PR TITLE
feat: availability messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The following Home Assistant entities are currently implemented:
 - Sensor
 - Binary sensor
 - Switch
+- Button
 
 ### Binary sensor
 
@@ -95,24 +96,22 @@ switch_info = SwitchInfo(name="test", command_topic="command")
 
 settings = Settings(mqtt=mqtt_settings, entity=switch_info)
 
+# To receive state commands from HA, define a callback function:
+def my_callback(client: Client, user_data, message: MQTTMessage):
+    payload = message.payload.decode()
+    logging.info(f"Received {payload} from HA")
+    # Your custom code...
+
+# Define an optional object to be passed back to the callback
+user_data = "Some custom data"
+
 # Instantiate the switch
-my_switch = Switch(settings)
+my_switch = Switch(settings, my_callback, user_data)
 
 # Change the state of the sensor, publishing an MQTT message that gets picked up by HA
 my_switch.on()
 my_switch.off()
 
-########### 
-# OPTIONAL
-# Receive state commands from HA. First, define a callback function:
-def my_callback(client: Client, userdata, message: MQTTMessage):
-    payload = message.payload.decode()
-    logging.info(f"Received {payload} from HA")
-    # Your custom code...
-
-# Note: `command_topic` must be set
-# Register the callback function to be invoked when HA send a state change in the `command_topic`
-my_switch.set_callback(my_callback)
 ```
 
 ## Device

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The following Home Assistant entities are currently implemented:
 
 - Sensor
 - Binary sensor
+- Switch
 
 ### Binary sensor
 
@@ -71,6 +72,47 @@ mysensor = BinarySensor(settings)
 mysensor.on()
 mysensor.off()
 
+```
+
+### Switch
+
+The switch is similar to a _binary sensor_, but in addition to publishing state changes toward HA it can also receive 'commands' from HA that request a state change.
+It is possible to act upon reception of this 'command', by defining a `callback` function, as the following example shows:
+
+#### Usage
+
+```py
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import Switch, SwitchInfo
+from paho.mqtt.client import Client, MQTTMessage
+
+# Configure the required parameters for the MQTT broker
+mqtt_settings = Settings.MQTT(host="localhost")
+
+# Information about the switch
+# If `command_topic` is defined, it will receive state updates from HA
+switch_info = SwitchInfo(name="test", command_topic="command")
+
+settings = Settings(mqtt=mqtt_settings, entity=switch_info)
+
+# Instantiate the switch
+my_switch = Switch(settings)
+
+# Change the state of the sensor, publishing an MQTT message that gets picked up by HA
+my_switch.on()
+my_switch.off()
+
+########### 
+# OPTIONAL
+# Receive state commands from HA. First, define a callback function:
+def my_callback(client: Client, userdata, message: MQTTMessage):
+    payload = message.payload.decode()
+    logging.info(f"Received {payload} from HA")
+    # Your custom code...
+
+# Note: `command_topic` must be set
+# Register the callback function to be invoked when HA send a state change in the `command_topic`
+my_switch.set_callback(my_callback)
 ```
 
 ## Device

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -547,7 +547,7 @@ class Settings(GenericModel, Generic[EntityType]):
     """Print out the message that would be sent over MQTT"""
     manual_availability: bool = False
     """If true, the entity `availability` inside HA must be manually managed
-    using the `available()` and `unavailable()` methods"""
+    using the `set_availability()` method"""
 
 
 class Discoverable(Generic[EntityType]):

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -6,7 +6,7 @@ import json
 import logging
 import ssl
 from importlib import metadata
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Callable, Generic, Optional, TypeVar
 
 import paho.mqtt.client as mqtt
 from pydantic import BaseModel, root_validator
@@ -15,6 +15,7 @@ from pydantic.generics import GenericModel
 # Read version from the package metadata
 __version__ = metadata.version(__package__)
 
+logger = logging.getLogger(__name__)
 
 CONFIGURATION_KEY_NAMES = {
     "act_t": "action_topic",
@@ -558,13 +559,17 @@ class Discoverable(Generic[EntityType]):
     state_topic: str
     availability_topic: str
 
-    def __init__(self, settings: Settings[EntityType]) -> None:
+    def __init__(
+        self, settings: Settings[EntityType], on_connect: Optional[Callable] = None
+    ) -> None:
         """
-        Setup the base discoverable object class
+        Creates a basic discoverable object.
 
         Args:
-            settings: Settings for the sensor we want to create in Home Assistant. \
-                See the `Settings` class for the available options.
+            settings: Settings for the entity we want to create in Home Assistant.
+            See the `Settings` class for the available options.
+            on_connect: Optional callback function invoked when the MQTT client successfully connects to the broker.
+            If defined, you need to call `_connect_client() to establish the connection manually.`
         """
         # Import here to avoid circular dependency on imports
         # TODO how to better handle this?
@@ -594,7 +599,11 @@ class Discoverable(Generic[EntityType]):
         logging.info(f"topic_prefix: {self._discovery_topic_prefix}")
         logging.info(f"self.state_topic: {self.state_topic}")
 
-        self._connect()
+        # Create the MQTT client, registering the user `on_connect` callback
+        self._setup_client(on_connect)
+        # If there is a callback function defined, the user must manually connect to the MQTT client
+        if not on_connect:
+            self._connect_client()
 
     def __str__(self) -> str:
         """
@@ -609,8 +618,8 @@ wrote_configuration: {self.wrote_configuration}
         """
         return dump
 
-    def _connect(self) -> None:
-        """Create an MQTT client and connect it to the broker"""
+    def _setup_client(self, on_connect: Optional[Callable] = None) -> None:
+        """Create an MQTT client and setup some basic properties on it"""
         mqtt_settings = self._settings.mqtt
         logging.debug(
             f"Creating mqtt client({mqtt_settings.client_name}) for {mqtt_settings.host}"
@@ -634,7 +643,13 @@ wrote_configuration: {self.wrote_configuration}
                 self.mqtt_client.username_pw_set(
                     mqtt_settings.username, password=mqtt_settings.password
                 )
-        result = self.mqtt_client.connect(mqtt_settings.host)
+        if on_connect:
+            logger.debug("Registering custom callback function")
+            self.mqtt_client.on_connect = on_connect
+
+    def _connect_client(self) -> None:
+        """Connect the client to the MQTT broker, start its onw internal loop in a separate thread"""
+        result = self.mqtt_client.connect(self._settings.mqtt.host)
         # Check if we have established a connection
         if result != mqtt.MQTT_ERR_SUCCESS:
             raise RuntimeError("Error while connecting to MQTT broker")
@@ -731,3 +746,55 @@ wrote_configuration: {self.wrote_configuration}
         logging.debug("Shutting down MQTT client")
         self.mqtt_client.disconnect()
         self.mqtt_client.loop_stop()
+
+
+class Subscriber(Discoverable[EntityType]):
+    """
+    Specialized sub-lass that listens to commands coming from an MQTT topic
+    """
+
+    T = TypeVar("T")  # Used in the callback function
+
+    def __init__(
+        self,
+        settings: Settings[EntityType],
+        command_callback: Callable[[mqtt.Client, T, mqtt.MQTTMessage], Any],
+        user_data: T = None,
+    ) -> None:
+        """
+        Entity that listens to commands from an MQTT topic.
+
+        Args:
+            settings: Settings for the entity we want to create in Home Assistant.
+            See the `Settings` class for the available options.
+            command_callback: Callback function invoked when there is a command
+            coming from the MQTT command topic
+        """
+        # Callback invoked when the MQTT connection is established
+        def on_client_connected(client: mqtt.Client, *args):
+            # Publish this button in Home Assistant
+            # Subscribe to the command topic
+            result, _ = client.subscribe(self._command_topic, qos=1)
+            if result is not mqtt.MQTT_ERR_SUCCESS:
+                raise RuntimeError("Error subscribing to MQTT command topic")
+
+        # Invoke the parent init
+        super().__init__(settings, on_client_connected)
+        # Define the command topic to receive commands from HA
+        self._command_topic = f"{self._discovery_topic_prefix}/command"
+
+        # Register the user-supplied callback function with its user_data
+        self.mqtt_client.user_data_set(user_data)
+        self.mqtt_client.on_message = command_callback
+
+        # Manually connect the MQTT client
+        self._connect_client()
+
+    def generate_config(self) -> dict[str, Any]:
+        """Override base config to add the command topic of this switch"""
+        config = super().generate_config()
+        # Add the MQTT command topic to the existing config object
+        topics = {
+            "command_topic": self._command_topic,
+        }
+        return config | topics

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -713,3 +713,9 @@ wrote_configuration: {self.wrote_configuration}
         Override in subclasses
         """
         self._state_helper(state=state)
+
+    def __del__(self):
+        """Cleanly shutdown the internal MQTT client"""
+        logging.debug("Shutting down MQTT client")
+        self.mqtt_client.disconnect()
+        self.mqtt_client.loop_stop()

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -9,6 +9,7 @@ from importlib import metadata
 from typing import Any, Callable, Generic, Optional, TypeVar
 
 import paho.mqtt.client as mqtt
+from paho.mqtt.client import MQTTMessageInfo
 from pydantic import BaseModel, root_validator
 from pydantic.generics import GenericModel
 
@@ -544,6 +545,9 @@ class Settings(GenericModel, Generic[EntityType]):
     entity: EntityType
     debug: bool = False
     """Print out the message that would be sent over MQTT"""
+    manual_availability: bool = False
+    """If true, the entity `availability` inside HA must be manually managed
+    using the `available()` and `unavailable()` methods"""
 
 
 class Discoverable(Generic[EntityType]):
@@ -605,6 +609,12 @@ class Discoverable(Generic[EntityType]):
         )
         logging.info(f"config_topic: {self.config_topic}")
         logging.info(f"state_topic: {self.state_topic}")
+        if self._settings.manual_availability:
+            # Define the availability topic, using `hmd` topic prefix
+            self.availability_topic = (
+                f"{self._settings.mqtt.state_prefix}/{self._entity_topic}/availability"
+            )
+            logger.debug(f"availability_topic: {self.availability_topic}")
 
         # Create the MQTT client, registering the user `on_connect` callback
         self._setup_client(on_connect)
@@ -654,6 +664,9 @@ wrote_configuration: {self.wrote_configuration}
             logger.debug("Registering custom callback function")
             self.mqtt_client.on_connect = on_connect
 
+        if self._settings.manual_availability:
+            self.mqtt_client.will_set(self.availability_topic, "offline", retain=True)
+
     def _connect_client(self) -> None:
         """Connect the client to the MQTT broker, start its onw internal loop in a separate thread"""
         result = self.mqtt_client.connect(self._settings.mqtt.host)
@@ -664,23 +677,27 @@ wrote_configuration: {self.wrote_configuration}
         # Start the internal network loop of the MQTT library to handle incoming messages in a separate thread
         self.mqtt_client.loop_start()
 
-    def _state_helper(self, state: Optional[str], topic: Optional[str] = None) -> None:
+    def _state_helper(
+        self, state: Optional[str], topic: Optional[str] = None
+    ) -> MQTTMessageInfo:
         """
-        Write a state to our MQTT state topic
+        Write a state to the given MQTT topic, return the result of client.publish()
         """
         if not self.wrote_configuration:
-            logging.debug("Writing sensor configuration")
+            logger.debug("Writing sensor configuration")
             self.write_config()
         if not topic:
-            logging.debug(f"State topic unset, using default '{self.state_topic}'")
+            logger.debug(f"State topic unset, using default: {self.state_topic}")
             topic = self.state_topic
-        logging.debug(f"Writing '{state}' to {topic}")
+        logger.debug(f"Writing '{state}' to {topic}")
 
         if self._settings.debug:
             logging.warning(f"Debug is {self.debug}, skipping state write")
             return
 
-        logging.warning(self.mqtt_client.publish(topic, state, retain=True))
+        message_info = self.mqtt_client.publish(topic, state, retain=True)
+        logger.debug(f"Publish result: {message_info}")
+        return message_info
 
     def debug_mode(self, mode: bool):
         self.debug = mode
@@ -717,6 +734,9 @@ wrote_configuration: {self.wrote_configuration}
         topics = {
             "state_topic": self.state_topic,
         }
+        # Add availability topic if defined
+        if hasattr(self, "availability_topic"):
+            topics["availability_topic"] = self.availability_topic
         return config | topics
 
     def write_config(self):
@@ -739,6 +759,12 @@ wrote_configuration: {self.wrote_configuration}
             return None
 
         return self.mqtt_client.publish(self.config_topic, config_message, retain=True)
+
+    def set_availability(self, availability: bool):
+        if not hasattr(self, "availability_topic"):
+            raise RuntimeError("Manual availability is not configured for this entity!")
+        message = "online" if availability else "offline"
+        self._state_helper(message, topic=self.availability_topic)
 
     def _update_state(self, state) -> None:
         """

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -577,10 +577,14 @@ class Discoverable(Generic[EntityType]):
 
         # Build the discovery topic string: append the type of component
         # e.g. `homeassistant/binary_sensor`
-        self._discovery_topic_prefix = f"{self._settings.mqtt.topic_prefix}/{self._entity.component}"
+        self._discovery_topic_prefix = (
+            f"{self._settings.mqtt.topic_prefix}/{self._entity.component}"
+        )
         # If present, append the device name
         # e.g. `homeassistant/binary_sensor/mydevice`
-        self._discovery_topic_prefix += f"/{clean_string(self._entity.device.name)}" if self._entity.device else ""
+        self._discovery_topic_prefix += (
+            f"/{clean_string(self._entity.device.name)}" if self._entity.device else ""
+        )
         # Append the sensor name
         # e.g. `homeassistant/binary_sensor/mydevice/mysensor`
         self._discovery_topic_prefix += f"/{clean_string(self._entity.name)}"

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -558,9 +558,6 @@ class Discoverable(Generic[EntityType]):
     state_topic: str
     availability_topic: str
 
-    class Config:
-        arbitrary_types_allowed = True
-
     def __init__(self, settings: Settings[EntityType]) -> None:
         """
         Setup the base discoverable object class
@@ -624,6 +621,8 @@ wrote_configuration: {self.wrote_configuration}
                         mqtt_settings.username, password=mqtt_settings.password
                     )
             self.mqtt_client.connect(mqtt_settings.host)
+            # Start the internal network loop of the MQTT library to handle incoming messages in a separate thread
+            self.mqtt_client.loop_start()
         else:
             logging.debug("Reusing existing MQTT client")
 

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -4,9 +4,9 @@
 # License: Apache 2.0
 
 import logging
-from typing import Optional
-
-from ha_mqtt_discoverable import Discoverable, EntityInfo
+from typing import Any, Callable, Optional
+from paho.mqtt.client import Client, MQTTMessage, MQTT_ERR_SUCCESS
+from ha_mqtt_discoverable import Discoverable, EntityInfo, Settings
 
 
 class BinarySensorInfo(EntityInfo):
@@ -28,6 +28,29 @@ class SensorInfo(EntityInfo):
     component: str = "sensor"
     unit_of_measurement: Optional[str] = None
     """Defines the units of measurement of the sensor, if any."""
+
+
+class SwitchInfo(EntityInfo):
+    """Switch specific information"""
+
+    component: str = "switch"
+    command_topic: Optional[str] = None
+    """The MQTT topic to publish commands to change the switch state."""
+    optimistic: Optional[bool] = None
+    """Flag that defines if switch works in optimistic mode.
+    Default: true if no state_topic defined, else false."""
+    payload_off: str = "ON"
+    """The payload that represents off state. If specified, will be used for both comparing
+    to the value in the state_topic (see value_template and state_off for details)
+    and sending as off command to the command_topic"""
+    payload_on: str = "OFF"
+    """The payload that represents on state. If specified, will be used for both comparing
+     to the value in the state_topic (see value_template and state_on for details)
+     and sending as on command to the command_topic."""
+    retain: Optional[bool] = None
+    """If the published message should have the retain flag on or not"""
+    state_topic: Optional[str] = None
+    """The MQTT topic subscribed to receive state updates."""
 
 
 class BinarySensor(Discoverable[BinarySensorInfo]):
@@ -70,3 +93,47 @@ class Sensor(Discoverable[SensorInfo]):
         """
         logging.info(f"Setting {self._entity.name} to {state} using {self.state_topic}")
         self._state_helper(str(state))
+
+
+class Switch(Discoverable[SwitchInfo]):
+    _command_topic: str
+
+    def __init__(self, settings: Settings[SwitchInfo]) -> None:
+        super().__init__(settings)
+        self._command_topic = f"{self.topic_prefix}/{self._entity.command_topic}"
+
+    def off(self):
+        """
+        Set switch to off
+        """
+        self._update_state(state=False)
+
+    def on(self):
+        """
+        Set switch to on
+        """
+        self._update_state(state=True)
+
+    def set_callback(self, callback: Callable[[Client, Any, MQTTMessage], Any]):
+        """Define a callback function that is invoked when Home Assistant request to change the state of this switch"""
+        self.mqtt_client.on_message = callback
+        result, _ = self.mqtt_client.subscribe(self._command_topic, qos=1)
+
+        if result is not MQTT_ERR_SUCCESS:
+            raise RuntimeError("Error subscribing to MQTT topic")
+
+    def _update_state(self, state: bool) -> None:
+        """
+        Update MQTT sensor state
+
+        Args:
+            state(bool): What state to set the sensor to
+        """
+        if state:
+            state_message = self._entity.payload_on
+        else:
+            state_message = self._entity.payload_off
+        logging.info(
+            f"Setting {self._entity.name} to {state_message} using {self.state_topic}"
+        )
+        self._state_helper(state=state_message)

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python3
 #
 # Copyright 2022 Joe Block <jpb@unixorn.net>
 # License: Apache 2.0
-from __future__ import annotations  # Required to define a class itself as type https://stackoverflow.com/a/33533514
+# Required to define a class itself as type https://stackoverflow.com/a/33533514
+from __future__ import annotations
 import logging
 from typing import Any, Callable, Optional, TypeVar
 from paho.mqtt.client import Client, MQTTMessage, MQTT_ERR_SUCCESS
@@ -53,6 +53,7 @@ class SwitchInfo(EntityInfo):
 
 class ButtonInfo(EntityInfo):
     """Button specific information"""
+
     component: str = "button"
 
     payload_press: str = "PRESS"
@@ -123,7 +124,9 @@ class Switch(Discoverable[SwitchInfo]):
         """
         self._update_state(state=True)
 
-    def set_callback(self, callback: Callable[[Client, T, MQTTMessage], Any], user_data: T = None):
+    def set_callback(
+        self, callback: Callable[[Client, T, MQTTMessage], Any], user_data: T = None
+    ):
         """
         Define a callback function that is invoked when Home Assistant request to change the state of this switch.
         If defined, the `user_data` parameter is passed back to the callback function
@@ -172,6 +175,7 @@ class Button(Discoverable[ButtonInfo]):
     """
     https://www.home-assistant.io/integrations/button.mqtt
     """
+
     T = TypeVar("T")  # Used in the callback function
     _command_topic: str
 
@@ -179,7 +183,9 @@ class Button(Discoverable[ButtonInfo]):
         super().__init__(settings)
         self._command_topic = f"{self._discovery_topic_prefix}/command"
 
-    def set_callback(self, callback: Callable[[Client, T, MQTTMessage], Any], user_data: T = None):
+    def set_callback(
+        self, callback: Callable[[Client, T, MQTTMessage], Any], user_data: T = None
+    ):
         """
         Define a callback function that is invoked when Home Assistant request a press of this button.
         If defined, the `user_data` parameter is passed back to the callback function
@@ -206,4 +212,3 @@ class Button(Discoverable[ButtonInfo]):
             "command_topic": self._command_topic,
         }
         return config | topics
-

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -103,7 +103,8 @@ class Sensor(Discoverable[SensorInfo]):
         self._state_helper(str(state))
 
 
-class Switch(Subscriber[SwitchInfo]):
+# Inherit the on and off methods from the BinarySensor class, changing only the documentation string
+class Switch(Subscriber[SwitchInfo], BinarySensor):
     """Implements an MQTT switch:
     https://www.home-assistant.io/integrations/switch.mqtt
     """
@@ -112,29 +113,13 @@ class Switch(Subscriber[SwitchInfo]):
         """
         Set switch to off
         """
-        self._update_state(state=False)
+        super().off()
 
     def on(self):
         """
         Set switch to on
         """
-        self._update_state(state=True)
-
-    def _update_state(self, state: bool) -> None:
-        """
-        Update MQTT sensor state
-
-        Args:
-            state(bool): What state to set the sensor to
-        """
-        if state:
-            state_message = self._entity.payload_on
-        else:
-            state_message = self._entity.payload_off
-        logging.info(
-            f"Setting {self._entity.name} to {state_message} using {self.state_topic}"
-        )
-        self._state_helper(state=state_message)
+        super().on()
 
 
 class Button(Subscriber[ButtonInfo]):

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -4,6 +4,7 @@
 # Required to define a class itself as type https://stackoverflow.com/a/33533514
 from __future__ import annotations
 import logging
+from typing import Optional
 from ha_mqtt_discoverable import Discoverable, EntityInfo, Subscriber
 
 

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -120,7 +120,7 @@ class Switch(Discoverable[SwitchInfo]):
         result, _ = self.mqtt_client.subscribe(self._command_topic, qos=1)
 
         if result is not MQTT_ERR_SUCCESS:
-            raise RuntimeError("Error subscribing to MQTT topic")
+            raise RuntimeError("Error subscribing to MQTT command topic")
 
     def _update_state(self, state: bool) -> None:
         """

--- a/poetry.lock
+++ b/poetry.lock
@@ -453,6 +453,24 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.10.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-mock-3.10.0.tar.gz", hash = "sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f"},
+    {file = "pytest_mock-3.10.0-py3-none-any.whl", hash = "sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b"},
+]
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -622,4 +640,4 @@ test = ["covdefaults (>=2.2.2)", "coverage (>=7.1)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10.0,<4.0"
-content-hash = "c95c5ddaaf72b8de47708fb86a5aca44ec7c79fafb6cc750236f6d5321f3907a"
+content-hash = "0badc60321e514f5cfb4c80b544ed63ca0a86340a00c4c1fb70577cecedd4ade"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pre-commit = "^3.1.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.2.1"
+pytest-mock = "^3.10.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,21 +1,21 @@
 import pytest
 from ha_mqtt_discoverable import Settings
-from ha_mqtt_discoverable.sensors import Switch, SwitchInfo
+from ha_mqtt_discoverable.sensors import Button, ButtonInfo
 
 
-@pytest.fixture(name="sensor")
-def switch() -> Switch:
+@pytest.fixture(name="button")
+def button() -> Button:
     mqtt_settings = Settings.MQTT(host="localhost")
-    sensor_info = SwitchInfo(name="test")
+    sensor_info = ButtonInfo(name="test")
     settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
     # Define an empty `command_callback`
-    return Switch(settings, lambda *_: None)
+    return Button(settings, lambda *_: None)
 
 
 def test_required_config():
     mqtt_settings = Settings.MQTT(host="localhost")
-    sensor_info = SwitchInfo(name="test")
+    sensor_info = ButtonInfo(name="test")
     settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
     # Define empty callback
-    sensor = Switch(settings, lambda *_: None)
+    sensor = Button(settings, lambda *_: None)
     assert sensor is not None

--- a/tests/test_discoverable.py
+++ b/tests/test_discoverable.py
@@ -2,7 +2,13 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import logging
 from threading import Event
-from paho.mqtt.client import Client, MQTTMessage, MQTTv5, SubscribeOptions, MQTT_ERR_SUCCESS
+from paho.mqtt.client import (
+    Client,
+    MQTTMessage,
+    MQTTv5,
+    SubscribeOptions,
+    MQTT_ERR_SUCCESS,
+)
 import pytest
 from pytest_mock import MockerFixture
 from ha_mqtt_discoverable import DeviceInfo, Discoverable, Settings, EntityInfo
@@ -45,7 +51,9 @@ def test_discovery_topics():
 def test_discovery_topics_with_device():
     mqtt_settings = Settings.MQTT(host="localhost")
     device = DeviceInfo(name="test_device", identifiers="id")
-    sensor_info = EntityInfo(name="test", component="binary_sensor", device=device, unique_id="unique_id")
+    sensor_info = EntityInfo(
+        name="test", component="binary_sensor", device=device, unique_id="unique_id"
+    )
     settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
     d = Discoverable[EntityInfo](settings)
     assert d._discovery_topic_prefix == "homeassistant/binary_sensor/test_device/test"
@@ -211,7 +219,7 @@ def test_publish_async(discoverable: Discoverable):
 
 def test_disconnect_client(mocker: MockerFixture):
     """Test that the __del__ method disconnects from the broker"""
-    mocked_client = mocker.patch('paho.mqtt.client.Client')
+    mocked_client = mocker.patch("paho.mqtt.client.Client")
     mock_instance = mocked_client.return_value
     mock_instance.connect.return_value = MQTT_ERR_SUCCESS
     mqtt_settings = Settings.MQTT(

--- a/tests/test_discoverable.py
+++ b/tests/test_discoverable.py
@@ -73,16 +73,17 @@ def test_custom_on_connect_must_be_called(mocker: MockerFixture):
     mock_instance.assert_not_called()
 
 
-def test_discovery_topics():
+def test_mqtt_topics():
     mqtt_settings = Settings.MQTT(host="localhost")
     sensor_info = EntityInfo(name="test", component="binary_sensor")
     settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
     d = Discoverable[EntityInfo](settings)
-    assert d._discovery_topic_prefix == "homeassistant/binary_sensor/test"
+    assert d._entity_topic == "binary_sensor/test"
     assert d.config_topic == "homeassistant/binary_sensor/test/config"
+    assert d.state_topic == "hmd/binary_sensor/test/state"
 
 
-def test_discovery_topics_with_device():
+def test_mqtt_topics_with_device():
     mqtt_settings = Settings.MQTT(host="localhost")
     device = DeviceInfo(name="test_device", identifiers="id")
     sensor_info = EntityInfo(
@@ -90,8 +91,9 @@ def test_discovery_topics_with_device():
     )
     settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
     d = Discoverable[EntityInfo](settings)
-    assert d._discovery_topic_prefix == "homeassistant/binary_sensor/test_device/test"
+    assert d._entity_topic == "binary_sensor/test_device/test"
     assert d.config_topic == "homeassistant/binary_sensor/test_device/test/config"
+    assert d.state_topic == "hmd/binary_sensor/test_device/test/state"
 
 
 def test_generate_config(discoverable: Discoverable):
@@ -100,7 +102,7 @@ def test_generate_config(discoverable: Discoverable):
     assert device_config is not None
     assert device_config["name"] == "test"
     assert device_config["component"] == "binary_sensor"
-    assert device_config["state_topic"] == "homeassistant/binary_sensor/test/state"
+    assert device_config["state_topic"] == "hmd/binary_sensor/test/state"
 
 
 def test_setup_client(discoverable: Discoverable):
@@ -216,7 +218,7 @@ def test_publish_multithread(discoverable: Discoverable):
     mqtt_client.on_message = message_callback
     mqtt_client.subscribe(
         (
-            "homeassistant/binary_sensor/test/state/#",
+            "hmd/binary_sensor/test/state/#",
             SubscribeOptions(retainHandling=SubscribeOptions.RETAIN_DO_NOT_SEND),
         )
     )
@@ -243,7 +245,7 @@ def test_publish_async(discoverable: Discoverable):
     mqtt_client.on_message = message_callback
     mqtt_client.subscribe(
         (
-            "homeassistant/binary_sensor/test/state/#",
+            "hmd/binary_sensor/test/state/#",
             SubscribeOptions(retainHandling=SubscribeOptions.RETAIN_DO_NOT_SEND),
         )
     )

--- a/tests/test_discoverable.py
+++ b/tests/test_discoverable.py
@@ -33,6 +33,25 @@ def test_missing_config():
         Settings(entity=sensor_info)  # type: ignore
 
 
+def test_discovery_topics():
+    mqtt_settings = Settings.MQTT(host="localhost")
+    sensor_info = EntityInfo(name="test", component="binary_sensor")
+    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+    d = Discoverable[EntityInfo](settings)
+    assert d._discovery_topic_prefix == "homeassistant/binary_sensor/test"
+    assert d.config_topic == "homeassistant/binary_sensor/test/config"
+
+
+def test_discovery_topics_with_device():
+    mqtt_settings = Settings.MQTT(host="localhost")
+    device = DeviceInfo(name="test_device", identifiers="id")
+    sensor_info = EntityInfo(name="test", component="binary_sensor", device=device, unique_id="unique_id")
+    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+    d = Discoverable[EntityInfo](settings)
+    assert d._discovery_topic_prefix == "homeassistant/binary_sensor/test_device/test"
+    assert d.config_topic == "homeassistant/binary_sensor/test_device/test/config"
+
+
 def test_generate_config(discoverable: Discoverable):
     device_config = discoverable.generate_config()
 

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -1,0 +1,62 @@
+import logging
+from threading import Event
+import time
+import pytest
+
+from ha_mqtt_discoverable import EntityInfo, Settings, Subscriber
+from paho.mqtt.client import MQTTMessage
+import paho.mqtt.publish as publish
+
+
+@pytest.fixture()
+def subscriber() -> Subscriber[EntityInfo]:
+    mqtt_settings = Settings.MQTT(host="localhost")
+    sensor_info = EntityInfo(name="test", component="button")
+    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+    # Define an empty `command_callback`
+    return Subscriber(settings, lambda *_: None)
+
+
+def test_required_config():
+    mqtt_settings = Settings.MQTT(host="localhost")
+    sensor_info = EntityInfo(name="test", component="button")
+    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+    # Define empty callback
+    sensor = Subscriber(settings, lambda *_: None)
+    assert sensor is not None
+
+
+def test_generate_config(subscriber: Subscriber):
+    config = subscriber.generate_config()
+
+    assert config is not None
+    # Check that command topic is part of the output config
+    assert config["command_topic"] == subscriber._command_topic
+
+
+def test_command_callback():
+    mqtt_settings = Settings.MQTT(host="localhost")
+    sensor_info = EntityInfo(name="test", component="switch")
+    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+
+    # Flag that waits for the command to be received
+    message_received = Event()
+
+    custom_user_data = "data"
+
+    # Callback to receive the command message
+    def custom_callback(client, user_data, message: MQTTMessage):
+        payload = message.payload.decode()
+        logging.info(f"Received {payload}")
+        assert payload == "on"
+        assert user_data == custom_user_data
+        message_received.set()
+
+    switch = Subscriber(settings, custom_callback, custom_user_data)
+    # Wait some seconds for the subscription to take effect
+    time.sleep(2)
+
+    # Send a command to the command topic
+    publish.single(switch._command_topic, "on", hostname="localhost")
+
+    assert message_received.wait(2)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -3,7 +3,7 @@ from ha_mqtt_discoverable import Settings
 from ha_mqtt_discoverable.sensors import Switch, SwitchInfo
 
 
-@pytest.fixture(name="sensor")
+@pytest.fixture()
 def switch() -> Switch:
     mqtt_settings = Settings.MQTT(host="localhost")
     sensor_info = SwitchInfo(name="test")
@@ -19,3 +19,8 @@ def test_required_config():
     # Define empty callback
     sensor = Switch(settings, lambda *_: None)
     assert sensor is not None
+
+
+def test_change_state(switch: Switch):
+    switch.on()
+    switch.off()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,53 @@
+import logging
+from threading import Event
+import time
+import pytest
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import Switch, SwitchInfo
+from paho.mqtt.publish import single
+from paho.mqtt.client import MQTTMessage
+
+
+@pytest.fixture(name="sensor")
+def switch() -> Switch:
+    mqtt_settings = Settings.MQTT(host="localhost")
+    sensor_info = SwitchInfo(name="test", command_topic="command")
+    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+    return Switch(settings)
+
+
+def test_required_config():
+    mqtt_settings = Settings.MQTT(host="localhost")
+    sensor_info = SwitchInfo(name="test")
+    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+    sensor = Switch(settings)
+    assert sensor is not None
+
+
+def test_generate_config(sensor: Switch):
+    config = sensor.generate_config()
+
+    assert config is not None
+    # If we have defined a command topic, check that is part of the output config
+    assert config["command_topic"] == sensor._entity.command_topic
+
+
+def test_set_callback(sensor: Switch):
+    message_received = Event()
+    sensor.write_config()
+
+    # Callback to receive the command message
+    def callback(client, userdata, message: MQTTMessage):
+        payload = message.payload.decode()
+        logging.info(f"Received {payload}")
+        assert payload == "on"
+        message_received.set()
+
+    sensor.set_callback(callback)
+    # Wait some seconds for the subscription to take effect
+    time.sleep(2)
+
+    # Send a command to the command topic
+    single(sensor._command_topic, "on", hostname="localhost")
+
+    assert message_received.wait(1)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -32,7 +32,7 @@ def test_generate_config(sensor: Switch):
     assert config["command_topic"] == sensor._entity.command_topic
 
 
-def test_set_callback(sensor: Switch):
+def test_callback(sensor: Switch):
     message_received = Event()
     sensor.write_config()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #10. 
Based on top of #36.

# Description
- Allow the end-user to manually configure the availability of an entity via `set_availability()` method
- Add an optional `manual_availability` configuration to enable the use of this additional method

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [x] Bug fix
- [x] New feature
- [x] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
