### PR TITLE
refactor(logger): use instance of `logger` class instead of importing `logging` directly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,10 @@
 repos:
   - repo: local
     hooks:
-      - id: format-python-files-with-black
-        name: Format python files with black
-        entry: ./hooks/scripts/format-python-files-with-black
-        language: script
+      # - id: format-python-files-with-black
+      #   name: Format python files with black
+      #   entry: ./hooks/scripts/format-python-files-with-black
+      #   language: script
       - id: clean-up-pyc-and-pyo-files
         name: Scrub all .pyc and .pyo files before committing
         entry: ./hooks/scripts/clean-up-pyc-and-pyo-files

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -607,8 +607,8 @@ class Discoverable(Generic[EntityType]):
         self.state_topic = (
             f"{self._settings.mqtt.state_prefix}/{self._entity_topic}/state"
         )
-        logging.info(f"config_topic: {self.config_topic}")
-        logging.info(f"state_topic: {self.state_topic}")
+        logger.info(f"config_topic: {self.config_topic}")
+        logger.info(f"state_topic: {self.state_topic}")
         if self._settings.manual_availability:
             # Define the availability topic, using `hmd` topic prefix
             self.availability_topic = (
@@ -638,15 +638,15 @@ wrote_configuration: {self.wrote_configuration}
     def _setup_client(self, on_connect: Optional[Callable] = None) -> None:
         """Create an MQTT client and setup some basic properties on it"""
         mqtt_settings = self._settings.mqtt
-        logging.debug(
+        logger.debug(
             f"Creating mqtt client({mqtt_settings.client_name}) for {mqtt_settings.host}"
         )
         self.mqtt_client = mqtt.Client(mqtt_settings.client_name)
         if mqtt_settings.tls_key:
-            logging.info(f"Connecting to {mqtt_settings.host} with SSL")
-            logging.debug(f"ca_certs={mqtt_settings.tls_ca_cert}")
-            logging.debug(f"certfile={mqtt_settings.tls_certfile}")
-            logging.debug(f"keyfile={mqtt_settings.tls_key}")
+            logger.info(f"Connecting to {mqtt_settings.host} with SSL")
+            logger.debug(f"ca_certs={mqtt_settings.tls_ca_cert}")
+            logger.debug(f"certfile={mqtt_settings.tls_certfile}")
+            logger.debug(f"keyfile={mqtt_settings.tls_key}")
             self.mqtt_client.tls_set(
                 ca_certs=mqtt_settings.tls_ca_cert,
                 certfile=mqtt_settings.tls_certfile,
@@ -655,7 +655,7 @@ wrote_configuration: {self.wrote_configuration}
                 tls_version=ssl.PROTOCOL_TLS,
             )
         else:
-            logging.warning(f"Connecting to {mqtt_settings.host} without SSL")
+            logger.debug(f"Connecting to {mqtt_settings.host} without SSL")
             if mqtt_settings.username:
                 self.mqtt_client.username_pw_set(
                     mqtt_settings.username, password=mqtt_settings.password
@@ -692,7 +692,7 @@ wrote_configuration: {self.wrote_configuration}
         logger.debug(f"Writing '{state}' to {topic}")
 
         if self._settings.debug:
-            logging.warning(f"Debug is {self.debug}, skipping state write")
+            logger.debug(f"Debug is {self.debug}, skipping state write")
             return
 
         message_info = self.mqtt_client.publish(topic, state, retain=True)
@@ -701,7 +701,7 @@ wrote_configuration: {self.wrote_configuration}
 
     def debug_mode(self, mode: bool):
         self.debug = mode
-        logging.warning(f"Set debug mode to {self.debug}")
+        logger.debug(f"Set debug mode to {self.debug}")
 
     def delete(self) -> None:
         """
@@ -716,7 +716,7 @@ wrote_configuration: {self.wrote_configuration}
         """
 
         config_message = ""
-        logging.info(
+        logger.info(
             f"Writing '{config_message}' to topic {self.config_topic} on {self._settings.mqtt.host}"
         )
         self.mqtt_client.publish(self.config_topic, config_message, retain=True)
@@ -748,14 +748,14 @@ wrote_configuration: {self.wrote_configuration}
         """
         config_message = json.dumps(self.generate_config())
 
-        logging.debug(
+        logger.debug(
             f"Writing '{config_message}' to topic {self.config_topic} on {self._settings.mqtt.host}"
         )
         self.wrote_configuration = True
         self.config_message = config_message
 
         if self._settings.debug:
-            logging.warning("Debug mode is enabled, skipping config write.")
+            logger.debug("Debug mode is enabled, skipping config write.")
             return None
 
         return self.mqtt_client.publish(self.config_topic, config_message, retain=True)
@@ -776,7 +776,7 @@ wrote_configuration: {self.wrote_configuration}
 
     def __del__(self):
         """Cleanly shutdown the internal MQTT client"""
-        logging.debug("Shutting down MQTT client")
+        logger.debug("Shutting down MQTT client")
         self.mqtt_client.disconnect()
         self.mqtt_client.loop_stop()
 
@@ -803,6 +803,7 @@ class Subscriber(Discoverable[EntityType]):
             command_callback: Callback function invoked when there is a command
             coming from the MQTT command topic
         """
+
         # Callback invoked when the MQTT connection is established
         def on_client_connected(client: mqtt.Client, *args):
             # Publish this button in Home Assistant

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -7,6 +7,8 @@ import logging
 from typing import Optional
 from ha_mqtt_discoverable import Discoverable, EntityInfo, Subscriber
 
+logger = logging.getLogger(__name__)
+
 
 class BinarySensorInfo(EntityInfo):
     """Binary sensor specific information"""
@@ -85,7 +87,7 @@ class BinarySensor(Discoverable[BinarySensorInfo]):
             state_message = self._entity.payload_on
         else:
             state_message = self._entity.payload_off
-        logging.info(
+        logger.info(
             f"Setting {self._entity.name} to {state_message} using {self.state_topic}"
         )
         self._state_helper(state=state_message)
@@ -99,7 +101,7 @@ class Sensor(Discoverable[SensorInfo]):
         Args:
             state(str): What state to set the sensor to
         """
-        logging.info(f"Setting {self._entity.name} to {state} using {self.state_topic}")
+        logger.info(f"Setting {self._entity.name} to {state} using {self.state_topic}")
         self._state_helper(str(state))
 
 

--- a/ha_mqtt_discoverable/settings.py
+++ b/ha_mqtt_discoverable/settings.py
@@ -1,8 +1,9 @@
-#!/usr/bin/env python3
-
 import logging
 
 from ha_mqtt_discoverable.utils import read_yaml_file
+
+
+logger = logging.getLogger(__name__)
 
 
 def load_mqtt_settings(path: str = None, cli=None) -> dict:
@@ -114,7 +115,7 @@ def binary_sensor_settings(path: str = None, cli=None) -> dict:
     settings = load_mqtt_settings(path=path, cli=cli)
     settings["state"] = cli.state
     settings["metric_name"] = cli.metric_name
-    logging.debug(f"settings: {settings}")
+    logger.debug(f"settings: {settings}")
     return settings
 
 
@@ -123,7 +124,7 @@ def device_settings(path: str = None, cli=None) -> dict:
     Load settings for a device
     """
     settings = load_mqtt_settings(path=path, cli=cli)
-    logging.debug(f"settings: {settings}")
+    logger.debug(f"settings: {settings}")
     if "unique_id" not in settings:
         raise RuntimeError("No unique_id was specified")
     return settings


### PR DESCRIPTION
# Description

- Customize the name of the logger with the module it is used in (otherwise they all appear as `__root__` in the console)
- Reduce the verbosity of some logs to debug, since they were at warning level
- Had to disable local `pre-commit` hook to commit this, see comment in #47

<!--- Describe your changes in detail -->

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [x] New feature
- [ ] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
